### PR TITLE
Increase deepdiff verbose level

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ example_test1.py:45: in test_user_profile_comparison
     assert expected == actual
 E   assert
 E     DeepAssert detailed comparison:
-E         Item root['permissions'][3] added to iterable.
+E         Item root['permissions'][3] ("delete") added to iterable.
 E         Value of root['user']['name'] changed from "John Doe" to "Jane Doe".
 E         Value of root['user']['email'] changed from "john@example.com" to "jane@example.com".
 E         Value of root['user']['preferences']['theme'] changed from "dark" to "light".

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-    
+
 # 🔍 pytest-deepassert
 
 </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pytest-deepassert"
-version = "0.1.2"
+version = "0.1.3"
 description = "A pytest plugin for enhanced assertion reporting with detailed diffs"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/pytest_deepassert/diff_report/report_generator.py
+++ b/src/pytest_deepassert/diff_report/report_generator.py
@@ -20,6 +20,7 @@ def generate_diff_report_lines(
             expected,
             actual,
             custom_operators=[custom_operator],
+            verbose_level=2,
             **kwargs,
         )
 


### PR DESCRIPTION
increased verbose level leads to added/removed iterable values also be included to the report, not just the index of added/removed value.

Resolves https://github.com/alexkuzmik/pytest-deepassert/issues/5